### PR TITLE
feat(multilayer-chart): user level access provided to deckgl charts in Slices

### DIFF
--- a/superset/views/chart/filters.py
+++ b/superset/views/chart/filters.py
@@ -18,10 +18,11 @@ from typing import Any
 
 from sqlalchemy import or_
 from sqlalchemy.orm.query import Query
-from superset.views.base import BaseFilter
+
+from superset import db, security_manager
 from superset.connectors.sqla import models
 from superset.utils.core import get_user_id
-from superset import security_manager, db
+from superset.views.base import BaseFilter
 
 
 class SliceFilter(BaseFilter):  # pylint: disable=too-few-public-methods


### PR DESCRIPTION
**SUMMARY**
- Providing access of deck.gl charts to the owners (except admin) while creating multi layer charts. 

**BEFORE SCREENSHOTS OR ANIMATED GIF**

https://user-images.githubusercontent.com/106157603/221788437-8f3a79a1-cd4f-4085-bbd1-7e60790bd5a7.mp4

**AFTER SCREENSHOTS OR ANIMATED GIF**

https://user-images.githubusercontent.com/106157603/211669359-11f022dd-5c69-479a-81d9-b6839aef22b9.mp4


**TESTING INSTRUCTIONS**
_FOR USERS OTHER THAN ADMIN_
- Configure the following keys in config.py according to the requirements:
    1.     MAPBOX_API_KEY 
- Route to Charts Screen.
- Create new chart using 'Multi Layer Deckgl Chart'.
- Deckgl charts dropdown should populate.

**ADDITIONAL INFORMATION**

- [x]  Changes In Filter: superset/views/chart/filters.py